### PR TITLE
ci: use node 18 & 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         # see https://github.com/nodejs/release#release-schedule
-        node: [ 16, 18 ]
+        node: [ 18, 20 ]
     steps:
       - uses: actions/checkout@v3
       - name: Setup node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
         # see https://github.com/nodejs/release#release-schedule
         node: [ 18, 20 ]
     steps:
+      - name: Set up foundry
+        uses: foundry-rs/foundry-toolchain@v1
       - uses: actions/checkout@v3
       - name: Setup node
         uses: actions/setup-node@v3


### PR DESCRIPTION
Node 16 will be deprecated 2023/09/11. At the time this SDK is released that should be the case. Testing for Node 16 doesn't really make sense.

see https://github.com/nodejs/release#release-schedule